### PR TITLE
Support homepage dashboard

### DIFF
--- a/helpdesk/views/public.py
+++ b/helpdesk/views/public.py
@@ -28,13 +28,7 @@ def homepage(request):
     if request.user.is_staff or \
             (request.user.is_authenticated and
              helpdesk_settings.HELPDESK_ALLOW_NON_STAFF_TICKET_UPDATE):
-        try:
-            if request.user.usersettings_helpdesk.settings.get('login_view_ticketlist', False):
-                return HttpResponseRedirect(reverse('helpdesk:list'))
-            else:
-                return HttpResponseRedirect(reverse('helpdesk:dashboard'))
-        except UserSettings.DoesNotExist:
-            return HttpResponseRedirect(reverse('helpdesk:dashboard'))
+        return HttpResponseRedirect(reverse('helpdesk:dashboard'))
 
     if request.method == 'POST':
         form = PublicTicketForm(request.POST, request.FILES)

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from distutils.util import convert_path
 from fnmatch import fnmatchcase
 from setuptools import setup, find_packages
 
-version = '0.2.6+nimbis.6'
+version = '0.2.6+nimbis.7'
 
 # Provided as an attribute, so you can append to these instead
 # of replicating them:


### PR DESCRIPTION
Bypass the login_view_ticketlist setting so that all logged in users are directed to the support dashboard.