### PR TITLE
Fix form of links sent to users in emails

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,0 +1,4 @@
+0.2.6+nimbis.13 (2018-04-27):
+
+    * Correct ticket URLs in outgoing email messages
+

--- a/Makefile
+++ b/Makefile
@@ -119,8 +119,108 @@ rundemo: demo
 rundemo2: demo2
 	demodesk runserver 8080
 
+VERSION := $(shell python ./setup.py --version 2>&1)
+RELEASE_TAG := v$(VERSION)
+PREV_VERSION := $(shell git describe --match='v*' 2>&1 | sed -e s'/\(v[0-9.]*\).*/\1/')
 
 #: release - Tag and push to PyPI.
 .PHONY: release
 release:
-	$(TOX) -e release
+	@echo ""
+
+	@echo "Performing pre-release checks for version $(VERSION)"
+
+	@echo -n "Looking for an existing tag $(RELEASE_TAG)... "
+	@if git tag -l $(RELEASE_TAG) | grep $(RELEASE_TAG); then \
+	    echo ""; \
+	    echo "Error: A release tag $(RELEASE_TAG) already exists."; \
+	    echo "  To make a new release, please increment the version"; \
+	    echo "  number in setup.py, (use semantic versioning).";\
+	    echo ""; \
+	    false; \
+	fi
+	@echo "None found. Good"
+
+	@echo -n "Looking for release notes for $(VERSION)... "
+	@if ! grep -q '^$(VERSION) ' CHANGES; then \
+	    echo "None found. Bad"; \
+	    echo ""; \
+	    echo "Error: No release notes found for version $(VERSION)"; \
+	    echo ""; \
+	    echo "  Please look through completed Trello cards and recent"; \
+	    echo "  commits, then summarize changes in the file"; \
+	    echo "  CHANGES"; \
+	    echo ""; \
+	    echo "  The following output may prove useful:"; \
+	    echo ""; \
+	    echo "  $$ git log $(PREV_VERSION).."; \
+	    echo ""; \
+	    git --no-pager log $(PREV_VERSION)..; \
+	    false; \
+	fi
+	@echo "Found them. Good"
+
+	@echo -n "Checking for locally-modified files... "
+	@mods=$$(git ls-files -m); if [ "$${mods}" != "" ]; then \
+	    echo "Found some. Bad"; \
+	    echo ""; \
+	    echo "Error: The following files have modifications."; \
+	    echo "  Please commit the desired changes to git before"; \
+	    echo "  attempting a release."; \
+	    echo ""; \
+	    echo "$$mods"; \
+	    echo ""; \
+	    false; \
+	fi
+	@echo "None found. Good"
+
+	@echo -n "Checking for unpushed commits..."
+	@commits=$$(git log --oneline origin/master..); \
+        if [ "$${commits}" != "" ]; then \
+	    echo "Found some. Bad"; \
+	    echo ""; \
+	    echo "Error: The following commits are not on origin/master."; \
+	    echo "  Please push these out before attempting a release."; \
+            echo ""; \
+            echo "$$commits"; \
+            echo ""; \
+            false; \
+        fi
+	@echo "None found. Good"
+
+	@echo ""
+	@echo "Preparing to package and release version $(VERSION)"
+	@echo "to the Nimbis private repository. You have 10 seconds to abort."
+	@echo ""
+	@for cnt in $$(seq 10 -1 1); do echo -n "$$cnt... "; sleep 1; done
+	@echo "0"
+
+	@echo "python setup.py sdist upload -r nimbis"
+	@if ! python setup.py sdist upload -r nimbis; then \
+	    echo ""; \
+	    echo "Error: Failed to upload new release."; \
+	    echo "  Please resolve any error messages above, and then"; \
+	    echo "  try again."; \
+	    false; \
+	fi
+
+	@echo ""
+	@echo "Successfully released a package with version $(VERSION)"
+
+	@if ! git tag -s -m "Release $(VERSION)" $(RELEASE_TAG); then \
+	    echo ""; \
+	    echo "Error: Packaged release has been uploaded, but failed to"; \
+	    echo "  create a tag. Please create and push a $(RELEASE_TAG)"; \
+	    echo "  tag manually now"; \
+	    false; \
+        fi
+
+	@if ! git push origin $(RELEASE_TAG); then \
+	    echo ""; \
+	    echo "Error: Packaged release has been uploaded and tagged."; \
+	    echo "  But an error occurred while pushing the tag. Please"; \
+	    echo "  manually push the $(RELEASE_TAG) tag now"; \
+	    false; \
+	fi
+
+

--- a/helpdesk/models.py
+++ b/helpdesk/models.py
@@ -557,11 +557,8 @@ class Ticket(models.Model):
         a URL to the submitter of a ticket.
         """
         from django.core.urlresolvers import reverse
-        return self._absolute_uri(u"%s?ticket=%s&email=%s" % (
-            reverse('helpdesk:public_view'),
-            self.ticket_for_url,
-            self.submitter_email
-        ))
+        return self._absolute_uri(
+            reverse('helpdesk:view', kwargs={'ticket_id': self.id}))
     ticket_url = property(_get_ticket_url)
 
     def _get_staff_url(self):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from distutils.util import convert_path
 from fnmatch import fnmatchcase
 from setuptools import setup, find_packages
 
-version = '0.2.6+nimbis.12'
+version = '0.2.6+nimbis.13'
 
 # Provided as an attribute, so you can append to these instead
 # of replicating them:


### PR DESCRIPTION
This makes the links that helpdesk sends to users in emails take the
form of something like:

http://www.trustedstratus.com/support/tickets/104/

Instead of:

http://www.trustedstratus.com/support/view/?ticket=general-104&email=carl.worth@nimbisservices.com