### PR TITLE
Remove attachments from all sent emails

### DIFF
--- a/CHANGES
+++ b/CHANGES
@@ -1,3 +1,7 @@
+0.2.6+nimbis.18 (2018-08-29):
+
+	* Remove attachments from all sent emails.
+
 0.2.6+nimbis.17 (2018-7-17):
 
 	* "Owned by me" tickets will now filter based on all django-allauth

--- a/helpdesk/forms.py
+++ b/helpdesk/forms.py
@@ -247,9 +247,7 @@ class AbstractTicketForm(CustomFieldMixin, forms.Form):
                 context,
                 recipients=ticket.submitter_email,
                 sender=queue.from_address,
-                fail_silently=True,
-                files=files,
-            )
+                fail_silently=True)
             messages_sent_to.append(ticket.submitter_email)
 
         if ticket.assigned_to and \
@@ -262,9 +260,7 @@ class AbstractTicketForm(CustomFieldMixin, forms.Form):
                 context,
                 recipients=ticket.assigned_to.email,
                 sender=queue.from_address,
-                fail_silently=True,
-                files=files,
-            )
+                fail_silently=True)
             messages_sent_to.append(ticket.assigned_to.email)
 
         if queue.new_ticket_cc and queue.new_ticket_cc not in messages_sent_to:
@@ -273,9 +269,7 @@ class AbstractTicketForm(CustomFieldMixin, forms.Form):
                 context,
                 recipients=queue.new_ticket_cc,
                 sender=queue.from_address,
-                fail_silently=True,
-                files=files,
-            )
+                fail_silently=True)
             messages_sent_to.append(queue.new_ticket_cc)
 
         if queue.updated_ticket_cc and \
@@ -286,9 +280,7 @@ class AbstractTicketForm(CustomFieldMixin, forms.Form):
                 context,
                 recipients=queue.updated_ticket_cc,
                 sender=queue.from_address,
-                fail_silently=True,
-                files=files,
-            )
+                fail_silently=True)
 
 
 class TicketForm(AbstractTicketForm):

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from distutils.util import convert_path
 from fnmatch import fnmatchcase
 from setuptools import setup, find_packages
 
-version = '0.2.6+nimbis.17'
+version = '0.2.6+nimbis.18'
 
 # Provided as an attribute, so you can append to these instead
 # of replicating them:
@@ -159,4 +159,3 @@ setup(
     zip_safe=False,
     install_requires=get_requirements(),
 )
-


### PR DESCRIPTION
All emails sent by helpdesk will no longer contain attachments. This is
done to prevent the leaking of potentially sensitive information.

Note that the ability to send attachments remains untouched but we are
just removing all the current uses of that feature.