### PR TITLE
Update submitter email on email update

### DIFF
--- a/helpdesk/__init__.py
+++ b/helpdesk/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'helpdesk.apps.HelpdeskConfig'

--- a/helpdesk/apps.py
+++ b/helpdesk/apps.py
@@ -4,3 +4,6 @@ from django.apps import AppConfig
 class HelpdeskConfig(AppConfig):
     name = 'helpdesk'
     verbose_name = "Helpdesk"
+
+    def ready(self):
+        import helpdesk.signals

--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -144,12 +144,9 @@ def send_templated_mail(template_name,
                     content = attachedfile.read()
                     msg.attach(filename, content)
             else:
-                if six.PY3:
-                    msg.attach_file(filepath)
-                else:
-                    with default_storage.open(filepath, 'rb') as attachedfile:
-                        content = attachedfile.read()
-                        msg.attach(filename, content)
+                with default_storage.open(filepath, 'rb') as attachedfile:
+                    content = attachedfile.read()
+                    msg.attach(filename, content)
 
     logger.debug('Sending email to: {!r}'.format(recipients))
 

--- a/helpdesk/signals.py
+++ b/helpdesk/signals.py
@@ -23,4 +23,4 @@ def update_ticket_submitter_email(sender, instance, **kwargs):
     tickets = Ticket.objects.filter(submitter_email=pre_save_user.email)
     for ticket in tickets:
         ticket.submitter_email = instance.email
-        ticket.save()
+        ticket.save(update_fields=['submitter_email'])

--- a/helpdesk/signals.py
+++ b/helpdesk/signals.py
@@ -9,7 +9,7 @@ from django.dispatch import receiver
 from .models import Ticket
 
 @receiver(pre_save, sender=User)
-def email_address_update(sender, instance, **kwargs):
+def update_ticket_submitter_email(sender, instance, **kwargs):
     qs = User.objects.filter(id=instance.id)
     if not qs:
         return

--- a/helpdesk/signals.py
+++ b/helpdesk/signals.py
@@ -1,0 +1,17 @@
+# -*- coding: utf-8 -*-
+
+from __future__ import absolute_import
+
+from django.contrib.auth.models import User
+from django.db.models.signals import pre_save
+from django.dispatch import receiver
+
+from .models import Ticket
+
+@receiver(pre_save, sender=User)
+def email_address_update(sender, instance, **kwargs):
+    pre_save_user = User.objects.get(id=instance.id)
+    tickets = Ticket.objects.filter(submitter_email=pre_save_user.email)
+    for ticket in tickets:
+        ticket.submitter_email = instance.email
+        ticket.save()

--- a/helpdesk/signals.py
+++ b/helpdesk/signals.py
@@ -10,11 +10,16 @@ from .models import Ticket
 
 @receiver(pre_save, sender=User)
 def update_ticket_submitter_email(sender, instance, **kwargs):
-    qs = User.objects.filter(id=instance.id)
-    if not qs:
+    pre_save_user = User.objects.filter(id=instance.id).first()
+
+    # If the user doesn't exist yet, then they won't have any tickets
+    if not pre_save_user:
         return
 
-    pre_save_user = qs.first()
+    # Make sure the email address actually changed
+    if pre_save_user.email == instance.email:
+        return
+
     tickets = Ticket.objects.filter(submitter_email=pre_save_user.email)
     for ticket in tickets:
         ticket.submitter_email = instance.email

--- a/helpdesk/signals.py
+++ b/helpdesk/signals.py
@@ -10,7 +10,11 @@ from .models import Ticket
 
 @receiver(pre_save, sender=User)
 def email_address_update(sender, instance, **kwargs):
-    pre_save_user = User.objects.get(id=instance.id)
+    qs = User.objects.filter(id=instance.id)
+    if not qs:
+        return
+
+    pre_save_user = qs.first()
     tickets = Ticket.objects.filter(submitter_email=pre_save_user.email)
     for ticket in tickets:
         ticket.submitter_email = instance.email

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from distutils.util import convert_path
 from fnmatch import fnmatchcase
 from setuptools import setup, find_packages
 
-version = '0.2.6+nimbis.22'
+version = '0.2.6+nimbis.22.1'
 
 # Provided as an attribute, so you can append to these instead
 # of replicating them:


### PR DESCRIPTION
This PR solves the issue where users change their email address and lose access to their tickets. This was because tickets are associated to users by the email address tied to the User object. This PR addresses this by creating a signal in helpdesk that detects changes to the User object and updates the email address appropriately.