### PR TITLE
Fix bug with attaching files when submitting follow-ups on tickets.

### DIFF
--- a/helpdesk/lib.py
+++ b/helpdesk/lib.py
@@ -144,12 +144,9 @@ def send_templated_mail(template_name,
                     content = attachedfile.read()
                     msg.attach(filename, content)
             else:
-                if six.PY3:
-                    msg.attach_file(filepath)
-                else:
-                    with default_storage.open(filepath, 'rb') as attachedfile:
-                        content = attachedfile.read()
-                        msg.attach(filename, content)
+                with default_storage.open(filepath, 'rb') as attachedfile:
+                    content = attachedfile.read()
+                    msg.attach(filename, content)
 
     logger.debug('Sending email to: {!r}'.format(recipients))
 


### PR DESCRIPTION
The following ISE was being thrown when users submitted a follow-up
response on a ticket and attaching any file:

Exception Type: FileNotFoundError at /support/tickets/<TICKET_ID>/update/
Exception Value: [Errno 2] No such file or directory:
'helpdesk/attachments/<SITE_ID-TICKET_ID>/...'

In this commit we switched to using S3 storage for attachments
in send_templated_mail:
https://github.com/nimbis/django-helpdesk/commit/7807b12a9c575d90364a67a18655ab87ed622da2

However, we did not apply that same change in the 'if six.PY3'
consequent. This path was not hit when were were running sites using
python2. Once we switched to python3, the bug fixed in the commit
above re-appeared.

Additionally, the latest version of django-helpdesk does not
include this if-then statement.

References:
https://github.com/django-helpdesk/django-helpdesk/issues/721
https://github.com/django-helpdesk/django-helpdesk/commit/b43e60875a3339c57a68a1405f6874d57a5c19a2#diff-798c61915598ee76b4cb2ee8be71c807